### PR TITLE
cmake: update linking and fix node path for ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall")
 # Appends the cmake/modules path to MAKE_MODULE_PATH variable.                                                                                                 
 set (CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
 
+find_package (Threads)
+
 find_package (SWIG)
 if (SWIG_FOUND)                                                                                                                                                
   include (${SWIG_USE_FILE})

--- a/languages/nodejs/CMakeLists.txt
+++ b/languages/nodejs/CMakeLists.txt
@@ -1,14 +1,12 @@
-#find_path (NODE_ROOT_DIR "node/node.h")                                                                   
+find_path (NODE_ROOT_DIR "node/node.h" "nodejs/node.h")
 
 set (NODE_INCLUDE_DIRS
-  ${NODE_ROOT_DIR}/src
   ${NODE_ROOT_DIR}/node
-  ${NODE_ROOT_DIR}/deps/v8/include
-  ${NODE_ROOT_DIR}/deps/uv/include
+  ${NODE_ROOT_DIR}/nodejs
 )
 
 include_directories (
-#  ${NODE_INCLUDE_DIRS}
+  ${NODE_INCLUDE_DIRS}
   ${CMAKE_SOURCE_DIR}/src
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ set (wyliodrin_LIB_SRCS
 )
 
 add_library (wyliodrin SHARED ${wyliodrin_LIB_SRCS})
-target_link_libraries (wyliodrin ${HIREDIS_LIBRARIES} ${JANSSON_LIBRARIES} -lrt -pthread -lmaa)
+target_link_libraries (wyliodrin ${HIREDIS_LIBRARIES} ${JANSSON_LIBRARIES} ${MAA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} -lrt)
 
 set_target_properties (
   wyliodrin


### PR DESCRIPTION
- ubuntu typically installs node.h in src/node.h so find_path now supports both
  paths
- use cmake to find appropriate threading library
- use pkgconfig output to find maa library

Signed-off-by: Brendan Le Foll brendan.le.foll@intel.com
