### PR TITLE
cmake: stop linking swig libs against libwyliodrin.so and make parralel ...

### DIFF
--- a/languages/nodejs/CMakeLists.txt
+++ b/languages/nodejs/CMakeLists.txt
@@ -15,7 +15,8 @@ set (CMAKE_CXX_FLAGS -DBUILDING_NODE_EXTENSION)
 set_source_files_properties (wyliodrin.i PROPERTIES SWIG_FLAGS "-node;-I${CMAKE_BINARY_DIR}/src")
 set_source_files_properties (wyliodrin.i PROPERTIES CPLUSPLUS ON)
 swig_add_module (wyliodrinjs javascript wyliodrin.i  ${wyliodrin_LIB_SRCS})
-swig_link_libraries (wyliodrinjs ${NODE_LIBRARIES} ${CMAKE_BINARY_DIR}/src/libwyliodrin.so)
+swig_link_libraries (wyliodrinjs ${NODE_LIBRARIES} ${HIREDIS_LIBRARIES} ${JANSSON_LIBRARIES} ${MAA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} -lrt)
+add_dependencies (${SWIG_MODULE_wyliodrinjs_REAL_NAME} wyliodrin)
 
 set_target_properties (wyliodrinjs PROPERTIES
   PREFIX ""

--- a/languages/python/CMakeLists.txt
+++ b/languages/python/CMakeLists.txt
@@ -9,7 +9,8 @@ include_directories (
 set_source_files_properties (wyliodrin.i PROPERTIES CPLUSPLUS ON)
 set_source_files_properties (wyliodrin.i PROPERTIES SWIG_FLAGS "-I${CMAKE_SOURCE_DIR}/src")
 swig_add_module (wyliodrin python wyliodrin.i ${wyliodrin_LIB_SRCS})
-swig_link_libraries (wyliodrin ${PYTHON_LIBRARIES} ${CMAKE_BINARY_DIR}/src/libwyliodrin.so)
+swig_link_libraries (wyliodrin ${PYTHON_LIBRARIES} ${HIREDIS_LIBRARIES} ${JANSSON_LIBRARIES} ${MAA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} -lrt)
+add_dependencies (${SWIG_MODULE_wyliodrin_REAL_NAME} wyliodrin)
 
 # Essentially do seperate_arguments but with "." instead of " "
 string (REPLACE "." ";" PYTHON_VERSION_LIST ${PYTHONLIBS_VERSION_STRING})


### PR DESCRIPTION
...compilation safe

Signed-off-by: Brendan Le Foll brendan.le.foll@intel.com
