### PR TITLE
libwyliodrin: rename maa to mraa and depend on version 0.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ if (SWIG_FOUND)
 endif ()
 
 find_package (PkgConfig REQUIRED)
-pkg_check_modules (MAA REQUIRED maa>=0.2.6)
-message (INFO " found libmaa version: ${MAA_VERSION}")
+pkg_check_modules (MRAA REQUIRED mraa>=0.4.0)
+message (INFO " found libmraa version: ${MRAA_VERSION}")
 
 find_package(Hiredis REQUIRED)
 include_directories(${HIREDIS_INCLUDE_DIR})

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Raspberry Pi
   * wiringPi
 
 ArduinoGalileo
-  * libmaa
+  * libmraa
 
 Languages
   * swig

--- a/languages/nodejs/CMakeLists.txt
+++ b/languages/nodejs/CMakeLists.txt
@@ -15,9 +15,9 @@ set (CMAKE_CXX_FLAGS -DBUILDING_NODE_EXTENSION)
 set_source_files_properties (wyliodrin.i PROPERTIES SWIG_FLAGS "-node;-I${CMAKE_BINARY_DIR}/src")
 set_source_files_properties (wyliodrin.i PROPERTIES CPLUSPLUS ON)
 swig_add_module (wyliodrinjs javascript wyliodrin.i  ${wyliodrin_LIB_SRCS})
-#swig_link_libraries (wyliodrinjs ${NODE_LIBRARIES} ${HIREDIS_LIBRARIES} ${JANSSON_LIBRARIES} ${MAA_LIBRARIES} ${CMAKE_CURRENT_BINARY_DIR}/../../src/libwyliodrin.so ${CMAKE_THREAD_LIBS_INIT} -lrt)
+#swig_link_libraries (wyliodrinjs ${NODE_LIBRARIES} ${HIREDIS_LIBRARIES} ${JANSSON_LIBRARIES} ${MRAA_LIBRARIES} ${CMAKE_CURRENT_BINARY_DIR}/../../src/libwyliodrin.so ${CMAKE_THREAD_LIBS_INIT} -lrt)
 #add_dependencies (${SWIG_MODULE_wyliodrinjs_REAL_NAME} wyliodrin)
-swig_link_libraries (wyliodrinjs ${NODE_LIBRARIES} ${HIREDIS_LIBRARIES} ${JANSSON_LIBRARIES} ${MAA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} -lrt)
+swig_link_libraries (wyliodrinjs ${NODE_LIBRARIES} ${HIREDIS_LIBRARIES} ${JANSSON_LIBRARIES} ${MRAA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} -lrt)
 
 set_target_properties (wyliodrinjs PROPERTIES
   PREFIX ""

--- a/languages/python/CMakeLists.txt
+++ b/languages/python/CMakeLists.txt
@@ -9,9 +9,9 @@ include_directories (
 set_source_files_properties (wyliodrin.i PROPERTIES CPLUSPLUS ON)
 set_source_files_properties (wyliodrin.i PROPERTIES SWIG_FLAGS "-I${CMAKE_SOURCE_DIR}/src")
 swig_add_module (wyliodrin python wyliodrin.i ${wyliodrin_LIB_SRCS})
-#swig_link_libraries (wyliodrin ${PYTHON_LIBRARIES} ${HIREDIS_LIBRARIES} ${JANSSON_LIBRARIES} ${MAA_LIBRARIES} ${CMAKE_CURRENT_BINARY_DIR}/../../src/libwyliodrin.so ${CMAKE_THREAD_LIBS_INIT} -lrt)
+#swig_link_libraries (wyliodrin ${PYTHON_LIBRARIES} ${HIREDIS_LIBRARIES} ${JANSSON_LIBRARIES} ${MRAA_LIBRARIES} ${CMAKE_CURRENT_BINARY_DIR}/../../src/libwyliodrin.so ${CMAKE_THREAD_LIBS_INIT} -lrt)
 #add_dependencies (${SWIG_MODULE_wyliodrin_REAL_NAME} wyliodrin)
-swig_link_libraries (wyliodrin ${PYTHON_LIBRARIES} ${HIREDIS_LIBRARIES} ${JANSSON_LIBRARIES} ${MAA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} -lrt)
+swig_link_libraries (wyliodrin ${PYTHON_LIBRARIES} ${HIREDIS_LIBRARIES} ${JANSSON_LIBRARIES} ${MRAA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} -lrt)
 
 # Essentially do seperate_arguments but with "." instead of " "
 string (REPLACE "." ";" PYTHON_VERSION_LIST ${PYTHONLIBS_VERSION_STRING})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library (wyliodrin SHARED ${wyliodrin_LIB_SRCS})
-target_link_libraries (wyliodrin ${HIREDIS_LIBRARIES} ${JANSSON_LIBRARIES} ${MAA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} -lrt)
+target_link_libraries (wyliodrin ${HIREDIS_LIBRARIES} ${JANSSON_LIBRARIES} ${MRAA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} -lrt)
 
 set_target_properties (
   wyliodrin

--- a/src/wiring/arduinogalileo.c
+++ b/src/wiring/arduinogalileo.c
@@ -3,10 +3,10 @@
 
 #include "wiring.h"
 
-static maa_gpio_context gpio_pins[MAX_GPIO_PINS];
-static maa_aio_context aio_pins[MAX_AIO_PINS];
-static maa_pwm_context pwm_pins[MAX_PWM_PINS];
-static maa_i2c_context i2c_buses[MAX_I2C_PINS];
+static mraa_gpio_context gpio_pins[MAX_GPIO_PINS];
+static mraa_aio_context aio_pins[MAX_AIO_PINS];
+static mraa_pwm_context pwm_pins[MAX_PWM_PINS];
+static mraa_i2c_context i2c_buses[MAX_I2C_PINS];
 
 // struct i2c_msg {
 // 	__u16 addr;	/* slave address			*/
@@ -29,7 +29,7 @@ void pwmReset (int pin);
 
 int wiringSetup ()
 {
-	maa_init ();
+	mraa_init ();
 }
 
 void pinReset (int pin)
@@ -41,11 +41,11 @@ void pinReset (int pin)
 
 void pwmReset (pin)
 {
-	maa_pwm_context p = maa_pwm_init (pin);
+	mraa_pwm_context p = mraa_pwm_init (pin);
 	if (p) 
 	{
-		maa_pwm_enable (p, 0);
-		maa_pwm_close (p);
+		mraa_pwm_enable (p, 0);
+		mraa_pwm_close (p);
 	}
 }
 
@@ -53,17 +53,17 @@ void resetPin (int pin)
 {
 	if (gpio_pins[pin] != NULL)
 	{
-		maa_gpio_close (gpio_pins[pin]);
+		mraa_gpio_close (gpio_pins[pin]);
 		gpio_pins[pin] = NULL;
 	}
 	if (pwm_pins[pin] != NULL)
 	{
-		maa_pwm_close (pwm_pins[pin]);
+		mraa_pwm_close (pwm_pins[pin]);
 		pwm_pins[pin] = NULL;
 	}
 	// if (aio_pins[pin] != NULL)
 	// {
-	// 	maa_aio_close (aio_pins[pin]);
+	// 	mraa_aio_close (aio_pins[pin]);
 	// 	aio_pins[pin] = NULL;
 	// }
 }
@@ -81,28 +81,28 @@ void pinMode (int pin, int mode)
 	if (!isGpioPin(pin))
 	{
 		resetPin (pin);
-		gpio_pins[pin] = maa_gpio_init (pin);
+		gpio_pins[pin] = mraa_gpio_init (pin);
 	}
 	if (mode == INPUT)
 	{
-		maa_gpio_dir (gpio_pins[pin], MAA_GPIO_IN);
+		mraa_gpio_dir (gpio_pins[pin], MRAA_GPIO_IN);
 	}
 	else if (mode == OUTPUT)
 	{
-		maa_gpio_dir (gpio_pins[pin], MAA_GPIO_OUT);
+		mraa_gpio_dir (gpio_pins[pin], MRAA_GPIO_OUT);
 	}
 }
 
 void digitalWrite (int pin, int value)
 {
 	outPin (pin);
-	maa_gpio_write (gpio_pins[pin], value);
+	mraa_gpio_write (gpio_pins[pin], value);
 }
 
 int digitalRead (int pin)
 {
 	inPin (pin);
-	return maa_gpio_read (gpio_pins[pin]);
+	return mraa_gpio_read (gpio_pins[pin]);
 }
 
 void analogWrite (int pin, int value)
@@ -110,13 +110,13 @@ void analogWrite (int pin, int value)
 	if (!isPwmPin (pin))
 	{
 		resetPin (pin);
-		pwm_pins[pin] = maa_pwm_init (pin);
+		pwm_pins[pin] = mraa_pwm_init (pin);
 	}
 	if (pwm_pins[pin])
 	{
-		maa_pwm_period_us(pwm_pins[pin], 1200);
-		maa_pwm_write (pwm_pins[pin], value/255.0);
-		maa_pwm_enable (pwm_pins[pin], 1);
+		mraa_pwm_period_us(pwm_pins[pin], 1200);
+		mraa_pwm_write (pwm_pins[pin], value/255.0);
+		mraa_pwm_enable (pwm_pins[pin], 1);
 	}
 	else
 	{
@@ -130,9 +130,9 @@ int analogRead (int pin)
 	if (!isAioPin (pin))
 	{
 		resetPin (pin);
-		aio_pins[pin] = maa_aio_init (pin);
+		aio_pins[pin] = mraa_aio_init (pin);
 	}
-	return maa_aio_read (aio_pins[pin]);
+	return mraa_aio_read (aio_pins[pin]);
 }
 
 void delay (int milliseconds)
@@ -213,33 +213,33 @@ int i2c_getadapter(uint32_t i2c_bus_address)
 
 int i2c_openadapter(uint8_t i2c_bus)
 {
-	i2c_buses[i2c_bus] = maa_i2c_init (i2c_bus);
+	i2c_buses[i2c_bus] = mraa_i2c_init (i2c_bus);
 	return i2c_bus;
 }
 
 int i2c_setslave(int i2c_bus, uint8_t addr)
 {
-	return maa_i2c_address (i2c_buses[i2c_bus], addr);
+	return mraa_i2c_address (i2c_buses[i2c_bus], addr);
 }
 
 int i2c_writebyte(int i2c_bus, uint8_t byte)
 {
-	return maa_i2c_write_byte (i2c_buses[i2c_bus], byte);
+	return mraa_i2c_write_byte (i2c_buses[i2c_bus], byte);
 }
 
 int i2c_writebytes(int i2c_bus, uint8_t *bytes, uint8_t length)
 {
-	return maa_i2c_write (i2c_buses[i2c_bus], bytes, length);
+	return mraa_i2c_write (i2c_buses[i2c_bus], bytes, length);
 }
 
 int i2c_readbyte(int i2c_bus)
 {
-	return maa_i2c_read_byte (i2c_buses[i2c_bus]);	
+	return mraa_i2c_read_byte (i2c_buses[i2c_bus]);	
 }
 
 int i2c_readbytes(int i2c_bus, uint8_t *buf, int length)
 {
-	return maa_i2c_read (i2c_buses[i2c_bus], buf, length);
+	return mraa_i2c_read (i2c_buses[i2c_bus], buf, length);
 }
 
 int i2c_readwrite(int i2c_bus)

--- a/src/wiring/wiring.h
+++ b/src/wiring/wiring.h
@@ -11,14 +11,14 @@ typedef unsigned char uint8_t;
 #endif
 
 // Arduino Galileo
-// use the maa library
+// use the mraa library
 #ifdef ARDUINOGALILEO
 
-#include <maa/gpio.h>
-#include <maa/aio.h>
-#include <maa/pwm.h>
-#include <maa/i2c.h>
-#include <maa/spi.h>
+#include <mraa/gpio.h>
+#include <mraa/aio.h>
+#include <mraa/pwm.h>
+#include <mraa/i2c.h>
+#include <mraa/spi.h>
 #include <unistd.h>
 
 #define MAX_GPIO_PINS 100

--- a/src/wyliodrin.i
+++ b/src/wyliodrin.i
@@ -14,7 +14,7 @@
 %}
 
 %init %{
-    //Adding maa_init() to the module initialisation process
+    //Adding mraa_init() to the module initialisation process
     wyliodrinSetup();
 %}
 


### PR DESCRIPTION
Signed-off-by: Brendan Le Foll brendan.le.foll@intel.com
